### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+# DEPRECATED REPOSITORY
+Please visit https://github.com/w3f/polkadot-wiki/tree/master/docs/learn/xcm for the latest XCM docs.
+
 # xcm-docs
 Documentation for XCM


### PR DESCRIPTION
Show a notice that the repository is deprecated and that readers should head to the W3F wiki repository for the latest XCM docs.