### PR TITLE
Mark as deprecated, point to new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# xcm-docs
-Documentation for XCM
+# XCM Docs - DEPRECATED
+
+The documentation for XCM has moved to [polkadot-sdk](https://github.com/paritytech/polkadot-sdk/) rust docs.
+You can find an online rendered version [here](https://paritytech.github.io/polkadot-sdk/master/xcm_docs/index.html).


### PR DESCRIPTION
Docs were moved to the polkadot-sdk rust docs, to keep in line with the overall rust docs effort and to make building examples easier.